### PR TITLE
[DAD-407] feat: 아티클, 상품 response 형식으로 변경

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -89,6 +89,7 @@ def crawling(url):
                 "author" : soup.select_one('.username').text,
                 "author_image_url" : None,
                 "blog_name" : soup.select_one('.user-logo').text,
+                "site_name" : "Velog",
                 "published_date" : published_date, 
             }
         elif url.find(".tistory.com") != -1 :
@@ -101,6 +102,7 @@ def crawling(url):
                 "author" : soup.select_one('meta[property="og.article.author"]')['content'],
                 "author_image_url" : None,
                 "blog_name" : soup.select_one('meta[property="og:site_name"]')['content'],
+                "site_name" : "Tistory",
                 "published_date" : soup.select_one('meta[property="article:published_time"]')['content'], #2021-03-05T10:53:30+09:00
             }
 
@@ -115,6 +117,7 @@ def crawling(url):
                 "author" : soup.select_one('meta[name="og:article:author"]')['content'],
                 "author_image_url" : None,
                 "blog_name" : soup.select_one('meta[property="og:site_name"]')['content'],
+                "site_name" : "Brunch",
                 "published_date" : soup.select_one('.date').text, #'2시간전'
             }
 
@@ -126,6 +129,7 @@ def crawling(url):
                 "title" : soup.select_one('meta[property="og:title"]')['content'],
                 "thumbnail_url" : soup.select_one('meta[property="og:image"]')['content'],
                 "price" : soup.select_one('meta[property="og:description"]')['content'].split(':')[1][1:], #12,900원
+                "site_name" : "11st",
             }
         
         #쿠팡
@@ -136,6 +140,7 @@ def crawling(url):
                 "title" : soup.select_one('meta[property="og:title"]')['content'],
                 "thumbnail_url" : soup.select_one('meta[property="og:image"]')['content'],
                 "price" : soup.select_one("span.total-price > strong").text, #3,999,000원
+                "site_name" : "Coupang",
             }
 
         else :


### PR DESCRIPTION
## 개요
- DAD-407

## 작업사항
- 크롤링 서버 API 응답 Body에 데이터 넣는 형식으로 변경
- 아티클, 상품 Response
- 아티클 중 네이버 블로그가 잘 안되어서 주석처리해놓은 상태
- 아티클에서 벨로그랑 브런치는 게시일이 '2일 전'처럼 되어서 '2023-07-17'처럼 변경하는 코드를 추후 작성해야함.