### PR TITLE
[DAD-873] fix: 운영 서버에서 url을 제대로 파싱하지 못하는 문제 해결

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -11,8 +11,11 @@ from other import crawlingOther
 
 def lambda_handler(event, context):
     
-    url = event['url']
-    url = url.strip()
+    try : url = event['url']
+    except(KeyError) : 
+        data = json.loads(event["body"])
+        url = data['url']
+        url = url.strip()
     
     return {
         'statusCode': 200,


### PR DESCRIPTION
## 개요
- DAD-873

## 작업사항
- lambda에서 직접 호출하는 url과 api gateway에서 호출하는 url을 받는 형식에 차이가 있는 것으로 확인
- 어디서 보내더라도 url을 모두 파싱할 수 있도록 코드 변경