### PR TITLE
[DAD-875] feat: encoding iso-8859-1로 되어 있는 웹 사이트도 해석할 수 있도록 변경

### DIFF
--- a/src/other.py
+++ b/src/other.py
@@ -13,8 +13,6 @@ def crawlingOther(url):
     if response.status_code == 200:
         html = response.text
 
-        print(response.encoding)
-
         if response.encoding.lower() == 'utf-8':
             soup = BeautifulSoup(response.content.decode('utf-8', 'replace'), 'html.parser')
     

--- a/src/other.py
+++ b/src/other.py
@@ -13,24 +13,29 @@ def crawlingOther(url):
     if response.status_code == 200:
         html = response.text
 
+        print(response.encoding)
+
         if response.encoding.lower() == 'utf-8':
             soup = BeautifulSoup(response.content.decode('utf-8', 'replace'), 'html.parser')
     
         elif response.encoding.lower() == 'ks_c_5601-1987':
             soup = BeautifulSoup(response.content.decode('ks_c_5601-1987', 'replace'), 'html.parser')
-    
-    result = {
-        "type": "other",
-        "page_url": url,
-    }
-    
-    try: result["title"] = soup.select_one('meta[property="og:title"]')['content']
-    except (TypeError, KeyError): result["title"] = None
 
-    try: result["thumbnail_url"] = soup.select_one('meta[property="og:image"]')['content']
-    except (TypeError, KeyError): result["thumbnail_url"] = None
+        elif response.encoding.lower() == 'iso-8859-1':
+            soup = BeautifulSoup(response.content.decode('iso-8859-1', 'replace'), 'html.parser')
+    
+        result = {
+            "type": "other",
+            "page_url": url,
+        }
         
-    try: result["description"] = soup.select_one('meta[property="og:description"]')['content']
-    except (TypeError, KeyError): result["description"] = None
+        try: result["title"] = soup.select_one('meta[property="og:title"]')['content']
+        except (TypeError, KeyError): result["title"] = None
 
-    return result
+        try: result["thumbnail_url"] = soup.select_one('meta[property="og:image"]')['content']
+        except (TypeError, KeyError): result["thumbnail_url"] = None
+            
+        try: result["description"] = soup.select_one('meta[property="og:description"]')['content']
+        except (TypeError, KeyError): result["description"] = None
+
+        return result

--- a/test/test_crawling_other.py
+++ b/test/test_crawling_other.py
@@ -10,3 +10,10 @@ def test_otherCrawling():
     assert result['type'] == 'other'
     assert result['title'] == '운영체제'
     assert result['thumbnail_url'] == 'http://www.kocw.net/common/contents/thumbnail/07/t1226304.jpg'
+
+def test_otherCrawling2():
+    result = crawlingOther("https://www.coursera.org/professional-certificates/meta-front-end-developer")
+
+    assert result['type'] == 'other'
+    assert result['title'] == 'Meta Front-End Developer'
+    assert result['thumbnail_url'] == 'https://s3.amazonaws.com/coursera_assets/meta_images/generated/XDP/XDP~SPECIALIZATION!~meta-front-end-developer/XDP~SPECIALIZATION!~meta-front-end-developer.jpeg'


### PR DESCRIPTION
## 개요
- DAD-875

## 작업사항
- request로 받아온 응답 encoding 확인하고 해당 해석하는 부분에서 ISO-8859-1 타입 로직 추가