### PR TITLE
[DAD-917] refactor: 특정 사이트 인코딩 문제 해결

### DIFF
--- a/src/other.py
+++ b/src/other.py
@@ -12,14 +12,15 @@ def crawlingOther(url):
 
     if response.status_code == 200:
         html = response.text
+        encoding = response.apparent_encoding
 
-        if response.encoding.lower() == 'utf-8':
+        if encoding == 'utf-8':
             soup = BeautifulSoup(response.content.decode('utf-8', 'replace'), 'html.parser')
     
-        elif response.encoding.lower() == 'ks_c_5601-1987':
+        elif encoding == 'ks_c_5601-1987':
             soup = BeautifulSoup(response.content.decode('ks_c_5601-1987', 'replace'), 'html.parser')
 
-        elif response.encoding.lower() == 'iso-8859-1':
+        elif encoding == 'iso-8859-1':
             soup = BeautifulSoup(response.content.decode('iso-8859-1', 'replace'), 'html.parser')
     
         result = {

--- a/test/test_crawling_other.py
+++ b/test/test_crawling_other.py
@@ -17,3 +17,10 @@ def test_otherCrawling2():
     assert result['type'] == 'other'
     assert result['title'] == 'Meta Front-End Developer'
     assert result['thumbnail_url'] == 'https://s3.amazonaws.com/coursera_assets/meta_images/generated/XDP/XDP~SPECIALIZATION!~meta-front-end-developer/XDP~SPECIALIZATION!~meta-front-end-developer.jpeg'
+
+def test_otherCrawling3():
+    result = crawlingOther("https://blog.ab180.co/posts/amplitude-retention")
+    
+    assert result['type'] == 'other'
+    assert result['title'] == 'Amplitude로 우리 제품의 리텐션 제대로 보는 방법'
+    assert result['thumbnail_url'] == 'https://assets-global.website-files.com/5f1008192dda2baf6f4e16c3/5f34a3d731072981ddf0bcaf_image--40-.png'


### PR DESCRIPTION
## 개요
- DAD-917

## 작업사항
- requests 라이브러리에서 response.encoding 일 때, header에 text/html 로 찍힌다면 html4에서는 iso-8867-1로 해석하고 html5에서는 utf-8로 인식하는 문제 해결 -> response.encoding을 사용하지 않고, response. apparent_encoding 사용하는 것으로 변경