### PR TITLE
[DAD-928] refactor: 썸네일 이미지를 og 태그에서 twitter, og 태그 순으로 탐색하는 로직으로 변경

### DIFF
--- a/src/other.py
+++ b/src/other.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+from urllib import parse
 
 def crawlingOther(url):
 
@@ -30,8 +31,17 @@ def crawlingOther(url):
         try: result["title"] = soup.select_one('meta[property="og:title"]')['content']
         except (TypeError, KeyError): result["title"] = None
 
-        try: result["thumbnail_url"] = soup.select_one('meta[property="og:image"]')['content']
-        except (TypeError, KeyError): result["thumbnail_url"] = None
+        try:
+            result["thumbnail_url"] = soup.select_one('meta[name="twitter:image"]')['content']
+        except (TypeError, KeyError):
+            try:
+                result["thumbnail_url"] = soup.select_one('meta[property="og:image"]')['content']
+            except (TypeError, KeyError):
+                result["thumbnail_url"] = None
+        
+        if(result["thumbnail_url"] != None and result["thumbnail_url"].startswith("/")):
+            parsed = parse.urlparse(url)
+            result["thumbnail_url"] = parsed.scheme + "://" + parsed.netloc + result["thumbnail_url"]
             
         try: result["description"] = soup.select_one('meta[property="og:description"]')['content']
         except (TypeError, KeyError): result["description"] = None

--- a/test/test_crawling_other.py
+++ b/test/test_crawling_other.py
@@ -17,3 +17,9 @@ def test_otherCrawling2():
     assert result['type'] == 'other'
     assert result['title'] == 'Meta Front-End Developer'
     assert result['thumbnail_url'] == 'https://s3.amazonaws.com/coursera_assets/meta_images/generated/XDP/XDP~SPECIALIZATION!~meta-front-end-developer/XDP~SPECIALIZATION!~meta-front-end-developer.jpeg'
+
+def test_otherCrawling5():
+    result = crawlingOther("https://haru-study.com/progress/522")
+    
+    assert result['type'] == 'other'
+    assert result['thumbnail_url'] == 'https://haru-study.com/assets/og-image.png'


### PR DESCRIPTION
## 개요
- DAD-928

## 작업사항
- result['thumbnail_url"] 값을 og:image에서 가져오던 것을 twitter:image를 먼저 탐색하고 없다면 og:image를 가져오는 로직으로 변경
-  '/'로 시작하는 이미지 url을 가지고 왔다면(상대 경로), 사이트 url을 기반으로 urllib 내장 라이브러리를 사용해 도메인을 확인하고 해당 경로를 그 뒤에 붙여서 절대 경로로 저장