### PR TITLE
[DAD-937] fix: thumbnail_url에서 '//'로 시작하는 url 앞에 'https'를 붙여 완전한 경로로 저장

### DIFF
--- a/src/other.py
+++ b/src/other.py
@@ -43,14 +43,14 @@ def crawlingOther(url):
                 result["thumbnail_url"] = soup.select_one('meta[property="og:image"]')['content']
             except (TypeError, KeyError):
                 result["thumbnail_url"] = None
-
-        if(result["thumbnail_url"] != None and result["thumbnail_url"].startswith("//")):
-            result["thumbnail_url"] = "https:" + result["thumbnail_url"]
-        
-        if(result["thumbnail_url"] != None and result["thumbnail_url"].startswith("/")):
-            parsed = parse.urlparse(url)
-            result["thumbnail_url"] = parsed.scheme + "://" + parsed.netloc + result["thumbnail_url"]
             
+        if(result["thumbnail_url"] is not None) :
+            if (result["thumbnail_url"].startswith("//")):
+                result["thumbnail_url"] = "https:" + result["thumbnail_url"]
+            elif (result["thumbnail_url"].startswith("/")):
+                parsed = parse.urlparse(url)
+                result["thumbnail_url"] = parsed.scheme + "://" + parsed.netloc + result["thumbnail_url"]
+
         try: result["description"] = soup.select_one('meta[property="og:description"]')['content']
         except (TypeError, KeyError): result["description"] = None
 

--- a/src/other.py
+++ b/src/other.py
@@ -43,6 +43,9 @@ def crawlingOther(url):
                 result["thumbnail_url"] = soup.select_one('meta[property="og:image"]')['content']
             except (TypeError, KeyError):
                 result["thumbnail_url"] = None
+
+        if(result["thumbnail_url"] != None and result["thumbnail_url"].startswith("//")):
+            result["thumbnail_url"] = "https:" + result["thumbnail_url"]
         
         if(result["thumbnail_url"] != None and result["thumbnail_url"].startswith("/")):
             parsed = parse.urlparse(url)
@@ -52,3 +55,4 @@ def crawlingOther(url):
         except (TypeError, KeyError): result["description"] = None
 
         return result
+

--- a/test/test_crawling_other.py
+++ b/test/test_crawling_other.py
@@ -37,4 +37,9 @@ def test_otherCrawling5():
     assert result['type'] == 'other'
     assert result['thumbnail_url'] == 'https://haru-study.com/assets/og-image.png'
 
+def test_otherCrawling6():
+    result = crawlingOther("https://www.tistory.com/auth/login?redirectUrl=https%3A%2F%2Fwhy-doing.tistory.com#")
 
+    assert result['type'] == 'other'
+    assert result['title'] == 'Tistory'
+    assert result['thumbnail_url'] == 'https://t1.daumcdn.net/tistory_admin/static/images/openGraph/tistoryOpengraph.png'


### PR DESCRIPTION
## 개요
- DAD-937

## 작업사항
- other 스크랩 저장할 때, thumbnail_url에서 '//'로 시작하는 url 앞에 'https'를 붙여 완전한 경로로 저장
- 후에 다른 카테고리의 스크랩도 같은 작업을 해주어야 함.